### PR TITLE
Life improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ function playCutscene(name:String)
 	video.finishCallback = function()
 	{
 		startCountdown();
-		startIntro.playAnim();
-		cameraMovement();
 	}
 }
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 # hxCodec - Native video support for OpenFL & Flixel
 
-# Credits
+[Original Repository](https://github.com/polybiusproxy/PolyEngine).
 
-- [PolybiusProxy (me)](https://github.com/polybiusproxy) - Creator of hxCodec.
+[Click here to check the roadmap of hxCodec here](https://github.com/brightfyregit/Friday-Night-Funkin-Mp4-Video-Support/projects/1)
+
+## Credits
+
+- [PolybiusProxy (me!)](https://github.com/polybiusproxy) - Creator of hxCodec.
 - [datee](https://github.com/datee) - Creator of HaxeVLC.
 - [BrightFyre](https://github.com/brightfyregit) - Creator of repository.
 - [GWebDev](https://github.com/GrowtopiaFli) - Inspiring me to do this.
 - [CryBit](https://github.com/CryBitDev) - fixing my shit lolololoolol
 - The contributors.
 
-[Original Repository](https://github.com/polybiusproxy/PolyEngine).
-
-[Click here to check the roadmap of hxCodec here](https://github.com/brightfyregit/Friday-Night-Funkin-Mp4-Video-Support/projects/1)
+## Instructions
+**These are for Friday Night Funkin mostly so it may not work for your flixel project.**
 
 ### 1. Download the repository:
 You can either download it as a ZIP,

--- a/README.md
+++ b/README.md
@@ -74,17 +74,7 @@ function playEndCutscene(name:String)
 }
 ```
 
-3. In the onFocus function
-```haxe
-video.resumeVideo();
-```
-
-4. In the onFocusLost function
-```haxe
-video.pauseVideo();
-```
-
-### 6. Example
+### 5. Example
 At PlayState create function
 ```haxe
 switch (curSong.toLowerCase())

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ You can either download it as a ZIP,
 or git cloning it.
 
 ### 2. Edit `Project.xml`
+Above
+```xml
+<assets path="assets/preload" rename="assets" exclude="*.ogg" if="web"/>
+```
+Add
 ```xml
 <assets path="assets/preload/videos" rename="assets/videos" include="*mp4" embed='false' />
 

--- a/README.md
+++ b/README.md
@@ -41,24 +41,7 @@ inline static public function video(key:String, ?library:String)
 }
 ```
 
-### 4. Edit `Main.hx`
-1. Set zoom to 1 instead of -1.
-2. Remove this code
-```haxe
-var stageWidth:Int = Lib.current.stage.stageWidth;
-var stageHeight:Int = Lib.current.stage.stageHeight;
-
-if (zoom == -1)
-{
-	var ratioX:Float = stageWidth / gameWidth;
-	var ratioY:Float = stageHeight / gameHeight;
-	zoom = Math.min(ratioX, ratioY);
-	gameWidth = Math.ceil(stageWidth / zoom);
-	gameHeight = Math.ceil(stageHeight / zoom);
-}
-```
-
-### 5. Playing videos
+### 4. Playing videos
 
 1. Put your video in `assets/preload/videos`.
 2. Create somewhere in PlayState

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# hxCodec - Native video support for HaxeFlixel/OpenFL
+# hxCodec - Native video support for OpenFL & Flixel
 
 # Credits
 

--- a/README.md
+++ b/README.md
@@ -1,164 +1,114 @@
 # hxCodec - Native video support for HaxeFlixel/OpenFL
-*Made by PolybiusProxy.*
 
-Original Repository - `https://github.com/polybiusproxy/PolyEngine`.
+# Credits
+
+- [PolybiusProxy (me)](https://github.com/polybiusproxy) - Creator of hxCodec.
+- [datee](https://github.com/datee) - Creator of HaxeVLC.
+- [BrightFyre](https://github.com/brightfyregit) - Creator of repository.
+- [GWebDev](https://github.com/GrowtopiaFli) - Inspiring me to do this.
+- [CryBit](https://github.com/CryBitDev) - fixing my shit lolololoolol
+- The contributors.
+
+[Original Repository](https://github.com/polybiusproxy/PolyEngine).
 
 [Click here to check the roadmap of hxCodec here](https://github.com/brightfyregit/Friday-Night-Funkin-Mp4-Video-Support/projects/1)
-  
+
 ### 1. Download the repository:
 You can either download it as a ZIP,
 or git cloning it.
 
 ### 2. Edit `Project.xml`
-
-After:
-
 ```xml
-<assets path="assets/week6"    library="week6"    exclude="*.ogg" if="web"/>
-<assets path="assets/week6"    library="week6"    exclude="*.mp3" unless="web"/>
+<assets path="assets/preload/videos" rename="assets/videos" include="*mp4" embed='false' />
+
+<assets path="plugins/" rename='' if="cpp" />
+<assets path="dlls/" rename='' if="cpp" />
 ```
 
-Put:
-
-```xml
-<assets path="assets/videos" exclude="*.mp3" if="web"/>
-<assets path="assets/videos" exclude="*.ogg" unless="web"/>
-
-<assets path="plugins/" rename='' if="windows"/>
-<assets path="dlls/" rename='' if="windows"/>
-```
-
-### 3. Setting up the paths
-
-In `Paths.hx`, put this code:
-
-After:
-```haxe	
-inline static public function soundRandom(key:String, min:Int, max:Int, ?library:String)
-{
-	return sound(key + FlxG.random.int(min, max), library);
-}
-```
-
-Put:
+### 3. Edit `Paths.hx`
 ```haxe
 inline static public function video(key:String, ?library:String)
 {
-	trace('assets/videos/$key.mp4');
 	return getPath('videos/$key.mp4', BINARY, library);
 }
 ```
 
-### 4. Playing videos
-
-Put your video in `assets/videos`.
-To play a video at the beginning of a week in Story Mode, add the following code in **`StoryMenuState.hx`**:
-
-First, add a variable called `isCutscene`:
-
+### 4. Edit `Main.hx`
+1. Set zoom to 1 instead of -1.
+2. Remove this code
 ```haxe
-var isCutscene:Bool = false;
-```
+var stageWidth:Int = Lib.current.stage.stageWidth;
+var stageHeight:Int = Lib.current.stage.stageHeight;
 
-Then replace these lines:
-
-```haxe 
-new FlxTimer().start(1, function(tmr:FlxTimer)
+if (zoom == -1)
 {
-	LoadingState.loadAndSwitchState(new PlayState(), true);
-});
-```
-
-with:
-
-```haxe
-var video:MP4Handler = new MP4Handler();
-
-if (curWeek == 0 && !isCutscene) // Checks if the current week is Tutorial.
-new FlxTimer().start(1, function(tmr:FlxTimer)
-{
-	{
-		video.playMP4(Paths.video('yourcutscenenamehere'));
-		video.finishCallback = function()
-	{
-		LoadingState.loadAndSwitchState(new PlayState());
-	}
-   	 	isCutscene = true;
-	}
-});
-else
-{
-    new FlxTimer().start(1, function(tmr:FlxTimer)
-    {
-        if (isCutscene)
-            video.onVLCComplete();
-
-        LoadingState.loadAndSwitchState(new PlayState(), true);
-    });
-```
-
-To play a cutscene before another week, replace `curWeek == 0` with the number of the week of your choice (-1, because arrays start from 0).
-
-To play a cutscene at the end of a song, place the following code in **`PlayState.hx`** before the line `prevCamFollow = camFollow;` in the `endSong()` function. You can wrap it in an "if" statement if you'd like to restrict it to a specific song.
-you should also add the isCutscene variable to PlayState, it solved a crash for some.
-
-```haxe
-var video:MP4Handler = new MP4Handler();
-
-video.playMP4(Paths.video('yourcutscene'));
-video.finishCallback = function()
-{
-	LoadingState.loadAndSwitchState(new PlayState());
+	var ratioX:Float = stageWidth / gameWidth;
+	var ratioY:Float = stageHeight / gameHeight;
+	zoom = Math.min(ratioX, ratioY);
+	gameWidth = Math.ceil(stageWidth / zoom);
+	gameHeight = Math.ceil(stageHeight / zoom);
 }
 ```
-If you are using the if statement, this code will work on Kade Engine 1.7 and up.
+
+### 5. Playing videos
+
+1. Put your video in `assets/preload/videos`.
+2. Create somewhere in PlayState
 ```haxe
-if (curSong.toLowerCase() == 'yoursonghere' && !isCutscene)
-{	
-	var video:MP4Handler = new MP4Handler();
-	
-	video.playMP4(Paths.video('yourcutscene'));
+var video:MP4Handler;
+
+function playCutscene(name:String)
+{
+	inCutscene = true;
+
+	video = new MP4Handler(Paths.video(name));
 	video.finishCallback = function()
 	{
+		startCountdown();
+		startIntro.playAnim();
+		cameraMovement();
+	}
+}
+
+function playEndCutscene(name:String)
+{
+	inCutscene = true;
+
+	video = new MP4Handler(Paths.video(name));
+	video.finishCallback = function()
+	{
+		SONG = Song.loadFromJson(storyPlaylist[0].toLowerCase());
 		LoadingState.loadAndSwitchState(new PlayState());
 	}
-	isCutscene = true;
 }
-else
+```
+
+3. In the onFocus function
+```haxe
+video.resumeVideo();
+```
+
+4. In the onFocusLost function
+```haxe
+video.pauseVideo();
+```
+
+### 6. Example
+At PlayState create function
+```haxe
+switch (curSong.toLowerCase())
 {
-	LoadingState.loadAndSwitchState(new PlayState());
+	case 'too-slow':
+		playCutscene('tooslowcutscene1');
+	case 'you-cant-run':
+		playCutscene('tooslowcutscene2');
+	default:
+		startCountdown();
 }
-
 ```
-<!-- You may have noticed a "clean()" function under the LoadingState state switch call, where the other LoadingState is and my solution to that is to not add it as it makes things unstable and crash other bugs, so dont add it. -->
 
-Make sure the name of the song is written correctly or else your game will **hard crash.**
-Then, comment out or delete the following lines immediately next to the code you just added.
-
+At PlayState endSong function
 ```haxe
-FlxTransitionableState.skipNextTransIn = true;
-FlxTransitionableState.skipNextTransOut = true;
+if (SONG.song.toLowerCase() == 'triple-trouble')
+	playEndCutscene('soundtestcodes');
 ```
-
-## Outputting to a FlxSprite
-
-There are many reasons to do this, as with a FlxSprite you can do layering in play state. or where ever else.
-To do this simply make a FlxSprite and do a playMP4 call with the argument. Then just add the sprite, and you're done!
-
-```haxe
-var sprite:FlxSprite = new FlxSprite(0,0);
-
-var video:MP4Handler = new MP4Handler();
-video.playMP4(Paths.video('yourvideonamehere'), null, sprite); // make the transition null so it doesn't take you out of this state
-
-add(sprite);
-```
-
-# Credits
-
-- [PolybiusProxy (me)](https://github.com/polybiusproxy) - Creator of hxCodec.
-- [datee]() - Creator of HaxeVLC.
-- [BrightFyre](https://github.com/brightfyregit) - Creator of repository.
-- [GWebDev](https://github.com/GrowtopiaFli) - Inspiring me to do this.
-- [CryBit](https://github.com/CryBitDev) - fixing my shit lolololoolol
-- The contributors.

--- a/README.md
+++ b/README.md
@@ -69,23 +69,25 @@ function playCutscene(name:String)
 {
 	inCutscene = true;
 
-	video = new MP4Handler(Paths.video(name));
+	video = new MP4Handler();
 	video.finishCallback = function()
 	{
 		startCountdown();
 	}
+	video.playVideo(Paths.video(name));
 }
 
 function playEndCutscene(name:String)
 {
 	inCutscene = true;
 
-	video = new MP4Handler(Paths.video(name));
+	video = new MP4Handler();
 	video.finishCallback = function()
 	{
 		SONG = Song.loadFromJson(storyPlaylist[0].toLowerCase());
 		LoadingState.loadAndSwitchState(new PlayState());
 	}
+	video.playVideo(Paths.video(name));
 }
 ```
 

--- a/source/MP4Handler.hx
+++ b/source/MP4Handler.hx
@@ -25,7 +25,7 @@ class MP4Handler extends vlc.VlcBitmap
 			FlxG.sound.music.pause();
 
 		onVideoReady = onVLCVideoReady;
-		onComplete = onVLCComplete;
+		onComplete = finishVideo;
 		onError = onVLCError;
 
 		this.repeat = repeat ? -1 : 0;
@@ -34,11 +34,16 @@ class MP4Handler extends vlc.VlcBitmap
 
 		FlxG.stage.addEventListener(Event.ENTER_FRAME, update);
 
+		// TODO: Remove this
 		playVideo(path);
 	}
 
 	function update(e:Event)
 	{
+		// TODO: Add so you press two times to skip
+		if (FlxG.keys.justPressed.ANY && isPlaying)
+			finishVideo();
+
 		volume = FlxG.sound.volume + 0.4;
 	}
 
@@ -65,16 +70,6 @@ class MP4Handler extends vlc.VlcBitmap
 			readyCallback();
 	}
 
-	function onVLCComplete()
-	{
-		if (FlxG.sound.music != null)
-			FlxG.sound.music.resume();
-
-		stop();
-
-		finishVideo();
-	}
-
 	function onVLCError()
 	{
 		// TODO: Catch the error
@@ -83,6 +78,9 @@ class MP4Handler extends vlc.VlcBitmap
 
 	public function finishVideo()
 	{
+		if (FlxG.sound.music != null)
+			FlxG.sound.music.resume();
+
 		dispose();
 
 		if (FlxG.game.contains(this))
@@ -101,15 +99,5 @@ class MP4Handler extends vlc.VlcBitmap
 		#else
 		throw "Doesn't support sys";
 		#end
-	}
-
-	public function pauseVideo()
-	{
-		pause();
-	}
-
-	public function resumeVideo()
-	{
-		resume();
 	}
 }

--- a/source/MP4Handler.hx
+++ b/source/MP4Handler.hx
@@ -12,12 +12,7 @@ class MP4Handler extends vlc.VlcBitmap
 	public var readyCallback:Void->Void;
 	public var finishCallback:Void->Void;
 
-	/**
-	 * Native video support for Flixel & OpenFL
-	 * @param path Example: `your/video/here.mp4`
-	 * @param repeat Repeat the video.
-	 */
-	public function new(path:String, ?repeat:Bool = false)
+	public function new()
 	{
 		super(FlxG.stage.stageWidth, FlxG.stage.stageHeight);
 
@@ -28,21 +23,23 @@ class MP4Handler extends vlc.VlcBitmap
 		onComplete = finishVideo;
 		onError = onVLCError;
 
-		this.repeat = repeat ? -1 : 0;
-
 		FlxG.addChildBelowMouse(this);
 
 		FlxG.stage.addEventListener(Event.ENTER_FRAME, update);
-
-		// TODO: Remove this
-		playVideo(path);
 	}
+
+	var pressOnce:Bool;
 
 	function update(e:Event)
 	{
-		// TODO: Add so you press two times to skip
-		if (FlxG.keys.justPressed.ANY && isPlaying)
-			finishVideo();
+		if (FlxG.keys.justPressed.ANY)
+		{
+			// TODO: Add where it resets after a while to false
+			if (!pressOnce)
+				pressOnce = true;
+			else if (isPlaying)
+				finishVideo();
+		}
 
 		volume = FlxG.sound.volume + 0.4;
 	}
@@ -81,6 +78,8 @@ class MP4Handler extends vlc.VlcBitmap
 		if (FlxG.sound.music != null)
 			FlxG.sound.music.resume();
 
+		FlxG.stage.removeEventListener(Event.ENTER_FRAME, update);
+
 		dispose();
 
 		if (FlxG.game.contains(this))
@@ -92,10 +91,17 @@ class MP4Handler extends vlc.VlcBitmap
 		}
 	}
 
-	public function playVideo(path:String)
+	/**
+	 * Native video support for Flixel & OpenFL
+	 * @param path Example: `your/video/here.mp4`
+	 * @param repeat Repeat the video.
+	 */
+	public function playVideo(path:String, ?repeat:Bool = false)
 	{
 		#if sys
 		play(checkFile(path));
+
+		this.repeat = repeat ? -1 : 0;
 		#else
 		throw "Doesn't support sys";
 		#end

--- a/source/MP4Handler.hx
+++ b/source/MP4Handler.hx
@@ -12,9 +12,9 @@ class MP4Handler extends vlc.VlcBitmap
 	public var readyCallback:Void->Void;
 	public var finishCallback:Void->Void;
 
-	public function new()
+	public function new(width:Float = 320, height:Float = 240, ?autoScale:Bool = true)
 	{
-		super(FlxG.stage.stageWidth, FlxG.stage.stageHeight);
+		super(width, height, autoScale);
 
 		if (FlxG.sound.music.playing)
 			FlxG.sound.music.pause();

--- a/source/MP4Handler.hx
+++ b/source/MP4Handler.hx
@@ -41,7 +41,10 @@ class MP4Handler extends vlc.VlcBitmap
 				finishVideo();
 		}
 
-		volume = FlxG.sound.volume + 0.4;
+		if (FlxG.sound.muted)
+			volume = 0;
+		else
+			volume = FlxG.sound.volume + 0.4;
 	}
 
 	#if sys

--- a/source/MP4Handler.hx
+++ b/source/MP4Handler.hx
@@ -12,7 +12,7 @@ class MP4Handler extends vlc.VlcBitmap
 	public var readyCallback:Void->Void;
 	public var finishCallback:Void->Void;
 
-	public function new(width:Float = 320, height:Float = 240, ?autoScale:Bool = true)
+	public function new(width:Float = 320, height:Float = 240, autoScale:Bool = true)
 	{
 		super(width, height, autoScale);
 
@@ -26,6 +26,15 @@ class MP4Handler extends vlc.VlcBitmap
 		FlxG.addChildBelowMouse(this);
 
 		FlxG.stage.addEventListener(Event.ENTER_FRAME, update);
+
+		FlxG.signals.focusGained.add(function()
+		{
+			resume();
+		});
+		FlxG.signals.focusLost.add(function()
+		{
+			pause();
+		});
 	}
 
 	var pressOnce:Bool;

--- a/source/MP4Handler.hx
+++ b/source/MP4Handler.hx
@@ -4,20 +4,19 @@ import openfl.events.Event;
 import flixel.FlxG;
 
 /**
- * The cpp version of playing a video
- * Use bitmap to return to a sprite or use `MP4Sprite`
+ * Play a video using cpp.
+ * Use bitmap to connect to a graphic or use `MP4Sprite`.
  */
 class MP4Handler extends vlc.VlcBitmap
 {
 	public var readyCallback:Void->Void;
 	public var finishCallback:Void->Void;
 
+	var pauseMusic:Bool;
+
 	public function new(width:Float = 320, height:Float = 240, autoScale:Bool = true)
 	{
 		super(width, height, autoScale);
-
-		if (FlxG.sound.music.playing)
-			FlxG.sound.music.pause();
 
 		onVideoReady = onVLCVideoReady;
 		onComplete = finishVideo;
@@ -37,20 +36,12 @@ class MP4Handler extends vlc.VlcBitmap
 		});
 	}
 
-	var pressOnce:Bool;
-
 	function update(e:Event)
 	{
-		if (FlxG.keys.justPressed.ANY)
-		{
-			// TODO: Add where it resets after a while to false
-			if (!pressOnce)
-				pressOnce = true;
-			else if (isPlaying)
-				finishVideo();
-		}
+		if ((FlxG.keys.justPressed.ENTER || FlxG.keys.justPressed.SPACE) && isPlaying)
+			finishVideo();
 
-		if (FlxG.sound.muted)
+		if (FlxG.sound.muted || FlxG.sound.volume <= 0)
 			volume = 0;
 		else
 			volume = FlxG.sound.volume + 0.4;
@@ -87,7 +78,7 @@ class MP4Handler extends vlc.VlcBitmap
 
 	public function finishVideo()
 	{
-		if (FlxG.sound.music != null)
+		if (FlxG.sound.music != null && pauseMusic)
 			FlxG.sound.music.resume();
 
 		FlxG.stage.removeEventListener(Event.ENTER_FRAME, update);
@@ -107,9 +98,15 @@ class MP4Handler extends vlc.VlcBitmap
 	 * Native video support for Flixel & OpenFL
 	 * @param path Example: `your/video/here.mp4`
 	 * @param repeat Repeat the video.
+	 * @param pauseMusic Pause music until done video.
 	 */
-	public function playVideo(path:String, ?repeat:Bool = false)
+	public function playVideo(path:String, ?repeat:Bool = false, pauseMusic:Bool = false)
 	{
+		this.pauseMusic = pauseMusic;
+
+		if (FlxG.sound.music != null && pauseMusic)
+			FlxG.sound.music.pause();
+
 		#if sys
 		play(checkFile(path));
 

--- a/source/MP4Sprite.hx
+++ b/source/MP4Sprite.hx
@@ -3,7 +3,7 @@ package;
 import flixel.FlxSprite;
 
 /**
- * Compared to `MP4Handler`. This loads faster!!
+ * Compared to `MP4Handler`. This loads slower!!
  */
 class MP4Sprite extends FlxSprite
 {

--- a/source/MP4Sprite.hx
+++ b/source/MP4Sprite.hx
@@ -40,10 +40,11 @@ class MP4Sprite extends FlxSprite
 	 * Native video support for Flixel & OpenFL
 	 * @param path Example: `your/video/here.mp4`
 	 * @param repeat Repeat the video.
+	 * @param pauseMusic Pause music until done video.
 	 */
-	public function playVideo(path:String, ?repeat:Bool = false)
+	public function playVideo(path:String, ?repeat:Bool = false, pauseMusic:Bool = false)
 	{
-		video.playVideo(path, repeat);
+		video.playVideo(path, repeat, pauseMusic);
 	}
 
 	public function pause()

--- a/source/MP4Sprite.hx
+++ b/source/MP4Sprite.hx
@@ -9,11 +9,11 @@ class MP4Sprite extends FlxSprite
 
 	var video:MP4Handler;
 
-	public function new(x:Float, y:Float, path:String, ?repeat:Bool = false)
+	public function new(x:Float, y:Float)
 	{
 		super(x, y);
 
-		video = new MP4Handler(path, repeat);
+		video = new MP4Handler();
 		video.alpha = 0;
 
 		video.readyCallback = function()
@@ -33,12 +33,22 @@ class MP4Sprite extends FlxSprite
 		};
 	}
 
-	public function pauseVideo()
+	/**
+	 * Native video support for Flixel & OpenFL
+	 * @param path Example: `your/video/here.mp4`
+	 * @param repeat Repeat the video.
+	 */
+	public function playVideo(path:String, ?repeat:Bool = false)
+	{
+		video.playVideo(path, repeat);
+	}
+
+	public function pause()
 	{
 		video.pause();
 	}
 
-	public function resumeVideo()
+	public function resume()
 	{
 		video.resume();
 	}

--- a/source/MP4Sprite.hx
+++ b/source/MP4Sprite.hx
@@ -2,6 +2,9 @@ package;
 
 import flixel.FlxSprite;
 
+/**
+ * Compared to `MP4Handler`. This loads faster!!
+ */
 class MP4Sprite extends FlxSprite
 {
 	public var readyCallback:Void->Void;
@@ -9,7 +12,7 @@ class MP4Sprite extends FlxSprite
 
 	var video:MP4Handler;
 
-	public function new(x:Float, y:Float)
+	public function new(?x:Float, ?y:Float)
 	{
 		super(x, y);
 

--- a/source/MP4Sprite.hx
+++ b/source/MP4Sprite.hx
@@ -12,11 +12,11 @@ class MP4Sprite extends FlxSprite
 
 	var video:MP4Handler;
 
-	public function new(?x:Float, ?y:Float)
+	public function new(x:Float = 0, y:Float = 0, width:Float = 320, height:Float = 240, autoScale:Bool = true)
 	{
 		super(x, y);
 
-		video = new MP4Handler();
+		video = new MP4Handler(width, height, autoScale);
 		video.alpha = 0;
 
 		video.readyCallback = function()
@@ -32,7 +32,7 @@ class MP4Sprite extends FlxSprite
 			if (finishCallback != null)
 				finishCallback();
 
-			destroy();
+			kill();
 		};
 	}
 

--- a/source/MP4Sprite.hx
+++ b/source/MP4Sprite.hx
@@ -1,0 +1,45 @@
+package;
+
+import flixel.FlxSprite;
+
+class MP4Sprite extends FlxSprite
+{
+	public var readyCallback:Void->Void;
+	public var finishCallback:Void->Void;
+
+	var video:MP4Handler;
+
+	public function new(x:Float, y:Float, path:String, ?repeat:Bool = false)
+	{
+		super(x, y);
+
+		video = new MP4Handler(path, repeat);
+		video.alpha = 0;
+
+		video.readyCallback = function()
+		{
+			loadGraphic(video.bitmapData);
+
+			if (readyCallback != null)
+				readyCallback();
+		}
+
+		video.finishCallback = function()
+		{
+			if (finishCallback != null)
+				finishCallback();
+
+			destroy();
+		};
+	}
+
+	public function pauseVideo()
+	{
+		video.pause();
+	}
+
+	public function resumeVideo()
+	{
+		video.resume();
+	}
+}

--- a/source/vlc/LibVLC.hx
+++ b/source/vlc/LibVLC.hx
@@ -1,14 +1,9 @@
 package vlc;
 
-import cpp.Callable;
-import cpp.Function;
+#if cpp
 import cpp.Pointer;
-import cpp.RawPointer;
 import cpp.UInt8;
-import haxe.io.ArrayBufferView;
-import lime.utils.UInt8Array;
-
-// import cpp.Void;
+#end
 
 /**
  * ...
@@ -112,8 +107,10 @@ extern class LibVLC
 	@:native("setRepeat")
 	public function setRepeat(repeat:Int = 1):Void;
 
+	#if cpp
 	@:native("getPixelData")
 	public function getPixelData():Pointer<UInt8>;
+	#end
 
 	@:native("getFPS")
 	public function getFPS():Float;

--- a/source/vlc/LibVLCBuild.xml
+++ b/source/vlc/LibVLCBuild.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <xml>
 	<set name="PROJECT_DIR" value="${this_dir}" />
 	<set name="CPP_DIR" value="${PROJECT_DIR}/cpp" />
@@ -11,5 +12,4 @@
 		<lib name='${CPP_DIR}/lib/libvlc.lib' if='windows'/>
 		<lib name='${CPP_DIR}/lib/libvlccore.lib' if='windows'/>
 	</target>
-	
 </xml>

--- a/source/vlc/VlcBitmap.hx
+++ b/source/vlc/VlcBitmap.hx
@@ -4,6 +4,7 @@ package vlc;
 import cpp.NativeArray;
 import cpp.UInt8;
 #end
+import flixel.FlxG;
 import openfl.Lib;
 import openfl.display.Bitmap;
 import openfl.display.BitmapData;
@@ -79,12 +80,20 @@ class VlcBitmap extends Bitmap
 
 	/////////////////////////////////////////////////////////////////////////////////////
 
-	public function new(width:Int = 320, height:Int = 240)
+	public function new(width:Float = 320, height:Float = 240, ?autoScale:Bool = true)
 	{
 		super(null, null, true);
 
-		this.width = width;
-		this.height = height;
+		if (autoScale)
+		{
+			this.width = getVideoWidth();
+			this.height = getVideoHeight();
+		}
+		else
+		{
+			this.width = width;
+			this.height = height;
+		}
 
 		init();
 	}
@@ -112,8 +121,24 @@ class VlcBitmap extends Bitmap
 
 	function onResize(e:Event)
 	{
-		width = FlxG.stage.stageWidth;
-		height = FlxG.stage.stageHeight;
+		width = getVideoWidth();
+		height = getVideoHeight();
+	}
+
+	function getVideoWidth():Float
+	{
+		if (FlxG.stage.stageHeight / 9 < FlxG.stage.stageWidth / 16)
+			return FlxG.stage.stageHeight * (16 / 9);
+		else
+			return FlxG.stage.stageWidth;
+	}
+
+	function getVideoHeight():Float
+	{
+		if (FlxG.stage.stageHeight / 9 < FlxG.stage.stageWidth / 16)
+			return FlxG.stage.stageHeight;
+		else
+			return FlxG.stage.stageWidth / (16 / 9);
 	}
 
 	/////////////////////////////////////////////////////////////////////////////////////

--- a/source/vlc/VlcBitmap.hx
+++ b/source/vlc/VlcBitmap.hx
@@ -1,13 +1,9 @@
 package vlc;
 
-import flixel.FlxG;
-import openfl.system.Capabilities;
-#if (cpp && !mobile)
+#if cpp
 import cpp.NativeArray;
 import cpp.UInt8;
-import haxe.ValueException;
-import haxe.io.Bytes;
-import lime.app.Application;
+#end
 import openfl.Lib;
 import openfl.display.Bitmap;
 import openfl.display.BitmapData;
@@ -21,9 +17,7 @@ import vlc.LibVLC;
  * ...
  * @author Tommy S
  */
-#if (cpp && !mobile)
 @:cppFileCode('#include "LibVLC.cpp"')
-#end
 class VlcBitmap extends Bitmap
 {
 	/////////////////////////////////////////////////////////////////////////////////////
@@ -38,9 +32,7 @@ class VlcBitmap extends Bitmap
 	public var repeat:Int = 0;
 	public var duration:Float;
 	public var length:Float;
-	public var inWindow:Bool;
 	public var initComplete:Bool;
-	public var fullscreen:Bool;
 	public var volume(default, set):Float = 1;
 
 	public var isDisposed:Bool;
@@ -63,10 +55,11 @@ class VlcBitmap extends Bitmap
 	// ===================================================================================
 	// Declarations
 	//-----------------------------------------------------------------------------------
+	#if cpp
 	var bufferMem:Array<UInt8>;
-	#if (cpp && !mobile)
-	var libvlc:LibVLC;
 	#end
+
+	var libvlc:LibVLC;
 
 	// ===================================================================================
 	// Variables
@@ -86,13 +79,14 @@ class VlcBitmap extends Bitmap
 
 	/////////////////////////////////////////////////////////////////////////////////////
 
-	public function new()
+	public function new(width:Int = 320, height:Int = 240)
 	{
 		super(null, null, true);
 
-		#if (cpp && !mobile)
+		this.width = width;
+		this.height = height;
+
 		init();
-		#end
 	}
 
 	function mThread()
@@ -104,9 +98,7 @@ class VlcBitmap extends Bitmap
 
 	function init()
 	{
-		#if (cpp && !mobile)
 		addEventListener(Event.ADDED_TO_STAGE, onAddedToStage);
-		#end
 	}
 
 	function onAddedToStage(e:Event):Void
@@ -118,38 +110,29 @@ class VlcBitmap extends Bitmap
 		stage.addEventListener(Event.ENTER_FRAME, vLoop);
 	}
 
+	function onResize(e:Event)
+	{
+		width = FlxG.stage.stageWidth;
+		height = FlxG.stage.stageHeight;
+	}
+
 	/////////////////////////////////////////////////////////////////////////////////////
 
 	public function play(?source:String)
 	{
-		#if (cpp && !mobile)
 		libvlc.setRepeat(repeat);
 
-		if (!inWindow)
-		{
-			if (source != null)
-				libvlc.play(source);
-			else
-				libvlc.play();
-		}
+		if (source != null)
+			libvlc.play(source);
 		else
-		{
-			if (source != null)
-				libvlc.playInWindow(source);
-			else
-				libvlc.playInWindow();
-
-			libvlc.setWindowFullscreen(fullscreen);
-		}
+			libvlc.play();
 
 		if (onPlay != null)
 			onPlay();
-		#end
 	}
 
 	public function stop()
 	{
-		#if (cpp && !mobile)
 		isPlaying = false;
 		libvlc.stop();
 		// if (disposeOnStop)
@@ -157,67 +140,51 @@ class VlcBitmap extends Bitmap
 
 		if (onStop != null)
 			onStop();
-		#end
 	}
 
 	public function pause()
 	{
-		#if (cpp && !mobile)
 		isPlaying = false;
 		libvlc.pause();
 		if (onPause != null)
 			onPause();
-		#end
 	}
 
 	public function resume()
 	{
-		#if (cpp && !mobile)
 		isPlaying = true;
 		libvlc.resume();
 		if (onResume != null)
 			onResume();
-		#end
 	}
 
 	public function seek(seekTotime:Float)
 	{
-		#if (cpp && !mobile)
 		libvlc.setPosition(seekTotime);
 		if (onSeek != null)
 			onSeek();
-		#end
 	}
 
 	public function getFPS():Float
 	{
-		#if (cpp && !mobile)
 		if (libvlc != null && initComplete)
 			return libvlc.getFPS();
 		else
 			return 0;
-		#else
-		return 0;
-		#end
 	}
 
 	public function getTime():Int
 	{
-		#if (cpp && !mobile)
 		if (libvlc != null && initComplete)
 			return libvlc.getTime();
 		else
 			return 0;
-		#else
-		return 0;
-		#end
 	}
 
 	/////////////////////////////////////////////////////////////////////////////////////
 
 	function checkFlags()
 	{
-		#if (cpp && !mobile)
 		if (!isDisposed)
 		{
 			if (untyped __cpp__('libvlc->flags[1]') == 1)
@@ -279,31 +246,12 @@ class VlcBitmap extends Bitmap
 				statusOnBackward();
 			}
 		}
-		#end
-	}
-
-	/////////////////////////////////////////////////////////////////////////////////////
-
-	function onResize(e:Event):Void
-	{
-		if (FlxG.stage.stageHeight / 9 < FlxG.stage.stageWidth / 16)
-		{
-			set_width(FlxG.stage.stageHeight * (16 / 9));
-			set_height(FlxG.stage.stageHeight);
-		}
-		else
-		{
-			set_width(FlxG.stage.stageWidth);
-			set_height(FlxG.stage.stageWidth / (16 / 9));
-		}
-		
 	}
 
 	/////////////////////////////////////////////////////////////////////////////////////
 
 	function videoInitComplete()
 	{
-		#if (cpp && !mobile)
 		videoWidth = libvlc.getWidth();
 		videoHeight = libvlc.getHeight();
 
@@ -338,7 +286,9 @@ class VlcBitmap extends Bitmap
 		else
 			height = videoHeight;
 
+		#if cpp
 		bufferMem = [];
+		#end
 		frameSize = videoWidth * videoHeight * 4;
 
 		setVolume(volume);
@@ -347,17 +297,14 @@ class VlcBitmap extends Bitmap
 
 		if (onVideoReady != null)
 			onVideoReady();
-		#end
 	}
 
 	/////////////////////////////////////////////////////////////////////////////////////
 
 	function vLoop(e)
 	{
-		#if (cpp && !mobile)
 		checkFlags();
 		render();
-		#end
 	}
 
 	/////////////////////////////////////////////////////////////////////////////////////
@@ -370,25 +317,26 @@ class VlcBitmap extends Bitmap
 		{
 			oldTime = cTime;
 
-			#if (cpp && !mobile)
 			// if (isPlaying && texture != null) // (Stage3D)
 			if (isPlaying)
 			{
 				try
 				{
+					#if cpp
 					NativeArray.setUnmanagedData(bufferMem, libvlc.getPixelData(), frameSize);
 					if (bufferMem != null)
 					{
 						// BitmapData
 						// libvlc.getPixelData() sometimes is null and the exe hangs ...
 						if (libvlc.getPixelData() != null)
-							bitmapData.setPixels(frameRect, Bytes.ofData(bufferMem));
+							bitmapData.setPixels(frameRect, haxe.io.Bytes.ofData(bufferMem));
 
 						// (Stage3D)
 						// texture.uploadFromByteArray( Bytes.ofData(cast(bufferMem)), 0 );
 						// this.width++; //This is a horrible hack to force the texture to update... Surely there is a better way...
 						// this.width--;
 					}
+					#end
 				}
 				catch (e:Error)
 				{
@@ -396,7 +344,6 @@ class VlcBitmap extends Bitmap
 					throw new Error("render broke xd");
 				}
 			}
-			#end
 		}
 	}
 
@@ -404,22 +351,16 @@ class VlcBitmap extends Bitmap
 
 	function setVolume(vol:Float)
 	{
-		#if (cpp && !mobile)
 		if (libvlc != null && initComplete)
 			libvlc.setVolume(vol * 100);
-		#end
 	}
 
 	public function getVolume():Float
 	{
-		#if (cpp && !mobile)
 		if (libvlc != null && initComplete)
 			return libvlc.getVolume();
 		else
 			return 0;
-		#else
-		return 0;
-		#end
 	}
 
 	/////////////////////////////////////////////////////////////////////////////////////
@@ -555,11 +496,10 @@ class VlcBitmap extends Bitmap
 
 	public function dispose()
 	{
-		#if (cpp && !mobile)
 		libvlc.stop();
-		#end
 
 		stage.removeEventListener(Event.ENTER_FRAME, vLoop);
+		stage.removeEventListener(Event.RESIZE, onResize);
 
 		if (texture != null)
 		{
@@ -576,18 +516,17 @@ class VlcBitmap extends Bitmap
 		onBuffer = null;
 		onProgress = null;
 		onError = null;
+		#if cpp
 		bufferMem = null;
+		#end
 		isDisposed = true;
 
-		#if (cpp && !mobile)
 		while (!isPlaying && !isDisposed)
 		{
 			libvlc.dispose();
 			libvlc = null;
 		}
-		#end
 	}
 
 	/////////////////////////////////////////////////////////////////////////////////////
 }
-#end


### PR DESCRIPTION
I'm not sure if this is buggy, but haven't run into any problems.

## StateCallback was removed due to...
- LoadingState Is something only fnf supports
- LoadingState is for when loading a week/shared folder
- People can add it to the finishCallback

## Major Changes
- removed stateCallback
- added readyCallback
- When trying to play videos during music will pause them. And resume after video is done playing.
- MP4Sprite has been added to clean up MP4Handler
- Fixed errors shown with VlcBitmap and LibVLC
- Made readme have examples on how to use in FNF